### PR TITLE
adjust code to new naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# clab-mdt-linker
-The clab-mdt-linker service enriches MDT data with the applied containerlab impairments
+# clab-telemetry-linker
+The clab-telemetry-linker service enriches telemetry data (YANG PUSH / model driven telemetry) with the applied containerlab impairments

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,41 +5,41 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/hawkv6/clab-mdt-linker/pkg/logging"
+	"github.com/hawkv6/clab-telemetry-linker/pkg/logging"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "clab-mdt-linker",
-	Short: "clab-mdt-linker is a tool to enricht mdt with containerlab impairments",
+	Use:   "clab-telemetry-linker",
+	Short: "clab-telemetry-linker is a tool to enricht telemetry with containerlab impairments",
 	Long: `
-clab-mdt-linker is a tool to enricht mdt with containerlab impairments
+clab-telemetry-linker is a tool to enricht telemetry with containerlab impairments
 
-Start the tool to listen for mdt data, enrich it with the containerlab impairements and send it to kafka
-clab-mdt-linker start --input-topic mdt --output-topic mdt-enriched --kafka-broker localhost:9092
+Start the tool to listen for telemetry data, enrich it with the containerlab impairements and send it to kafka
+clab-telemetry-linker start --input-topic telemetry --output-topic telemetry-enriched --kafka-broker localhost:9092
 
 Set the impairments on the containerlab interface
-clab-mdt-linker set -n clab-hawkv6-XR-1 -i Gi0-0-0-0 --delay 1ms --jitter 1ms --loss 5 --rate 100
+clab-telemetry-linker set -n clab-hawkv6-XR-1 -i Gi0-0-0-0 --delay 1ms --jitter 1ms --loss 5 --rate 100
 -----------+-------+--------+-------------+-------------+
 | Interface | Delay | Jitter | Packet Loss | Rate (kbit) |
 +-----------+-------+--------+-------------+-------------+
 | Gi0-0-0-0 | 1ms   | 1ms    | 5.00%       |         100 |
 +-----------+-------+--------+-------------+-------------+
 
-clab-mdt-linker show -n clab-hawkv6-XR-1 -i Gi0-0-0-1 
+clab-telemetry-linker show -n clab-hawkv6-XR-1 -i Gi0-0-0-1 
 +-----------+-------+--------+-------------+-------------+
 | Interface | Delay | Jitter | Packet Loss | Rate (kbit) |
 +-----------+-------+--------+-------------+-------------+
 | Gi0-0-0-1 | 100ms | 0s     | 10.00%      |           0 |
 +-----------+-------+--------+-------------+-------------+
 
-clab-mdt-linker delete -n clab-hawkv6-XR-1 -i Gi0-0-0-0
+clab-telemetry-linker delete -n clab-hawkv6-XR-1 -i Gi0-0-0-0
 +-----------+-------+--------+-------------+-------------+
 | Interface | Delay | Jitter | Packet Loss | Rate (kbit) |
 +-----------+-------+--------+-------------+-------------+
 | Gi0-0-0-0 | 0ms   | 0s     | 0.00%       |           0 |
 +-----------+-------+--------+-------------+-------------+
 	
-clab-mdt-linker will forward the impairments to the specific containerlab command
+clab-telemetry-linker will forward the impairments to the specific containerlab command
 More information: https://containerlab.dev/cmd/tools/netem/set/
 `,
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hawkv6/clab-mdt-linker
+module github.com/hawkv6/clab-telemetry-linker
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/hawkv6/clab-mdt-linker/cmd"
+	"github.com/hawkv6/clab-telemetry-linker/cmd"
 )
 
 func main() {

--- a/pkg/logging/logging/logging.go
+++ b/pkg/logging/logging/logging.go
@@ -1,0 +1,17 @@
+package logging
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var DefaultLogger = InitializeDefaultLogger()
+
+func InitializeDefaultLogger() (logger *logrus.Logger) {
+	logger = logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors: true,
+		FullTimestamp: true,
+	})
+	return
+}

--- a/pkg/logging/logging/logging_test.go
+++ b/pkg/logging/logging/logging_test.go
@@ -1,0 +1,10 @@
+package logging
+
+import "testing"
+
+func TestIntializeDefaultLogger(t *testing.T) {
+	logger := InitializeDefaultLogger()
+	if logger == nil {
+		t.Errorf("logger is nil")
+	}
+}


### PR DESCRIPTION
Change repo name `clab-mdt-linker` -> `clab-telemetry-linker` 