### PR TITLE
Fix first startup bug

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const MAJOR uint = 1
 const MINOR uint = 0
-const PATCH uint = 4
+const PATCH uint = 5
 
 func GetVersion() string {
 	return fmt.Sprintf("%d.%d.%d", MAJOR, MINOR, PATCH)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -116,6 +116,7 @@ func (config *DefaultConfig) InitConfig() error {
 		if err := config.createConfig(); err != nil {
 			return err
 		}
+		return config.WriteConfig()
 	}
 	if err := config.readConfig(); err != nil {
 		return err


### PR DESCRIPTION
So, the initial config was not written, which led to the bug that the impairments could not be set because the clab-name (prefix) for all docker hosts was not there:

```
ins@dels-ibn-jagw:~$ sudo clab-telemetry-linker set -n XR-1 -i Gi0-0-0-1 -d 4
INFO[2025-04-17T08:46:06Z] Read config file:  /home/ins/.clab-telemetry-linker/config.yaml  subsystem=config
ERRO[2025-04-17T08:46:06Z] Error applying impairments: Aborting... Following Error happened: Error: Error response from daemon: No such container: -XR-1
  subsystem=cmd
FATA[2025-04-17T08:46:06Z] Error reverting impairments: Aborting... Following Error happened: Error: Error response from daemon: No such container: -XR-1
  subsystem=cmd
```

The added code fixes this bug:
```
ins@dels-ibn-jagw:~$ sudo clab-telemetry-linker set -n XR-1 -i Gi0-0-0-1 -d 4
INFO[2025-04-17T08:45:41Z] Read config file:  /home/ins/.clab-telemetry-linker/config.yaml  subsystem=config
╭───────────┬───────┬────────┬─────────────┬─────────────┬────────────╮
│ Interface │ Delay │ Jitter │ Packet Loss │ Rate (Kbit) │ Corruption │
├───────────┼───────┼────────┼─────────────┼─────────────┼────────────┤
│ Gi0-0-0-1 │ 4ms   │ 0s     │ 0.00%       │ 0           │ 0.00%      │
╰───────────┴───────┴────────┴─────────────┴─────────────┴────────────╯
```


Please review the changes and merge them if they look good to you.
